### PR TITLE
Circumvent PHP's is_writable ACL bug

### DIFF
--- a/libs/internals/core.write_compiled_resource.php
+++ b/libs/internals/core.write_compiled_resource.php
@@ -6,6 +6,35 @@
  */
 
 /**
+ * Check to see if the path is writable on a Windows machine
+ * Copied from http://php.net/manual/en/function.is-writable.php comment by
+ * legolas558
+ *
+ * Added 04/03/2015 by Yola to address is_writable PHP bug that does not
+ * correctly handle ACL on Windows platforms.
+ */
+function is_writable_win($path) {
+//will work in despite of Windows ACLs bug
+//NOTE: use a trailing slash for folders!!!
+//see http://bugs.php.net/bug.php?id=27609
+//see http://bugs.php.net/bug.php?id=30931
+
+    if ($path{strlen($path)-1}=='/') // recursively return a temporary file path
+        return is__writable($path.uniqid(mt_rand()).'.tmp');
+    else if (is_dir($path))
+        return is__writable($path.'/'.uniqid(mt_rand()).'.tmp');
+    // check tmp file for read/write capabilities
+    $rm = file_exists($path);
+    $f = @fopen($path, 'a');
+    if ($f===false)
+        return false;
+    fclose($f);
+    if (!$rm)
+        unlink($path);
+    return true;
+}
+
+/**
  * write the compiled resource
  *
  * @param string $compile_path
@@ -14,7 +43,18 @@
  */
 function smarty_core_write_compiled_resource($params, &$smarty)
 {
-    if(!@is_writable($smarty->compile_dir)) {
+    /**
+     * Detect if running on a Windows server
+     * Added 04/03/2015 by Yola. Necessary to avoid bug in PHP with
+     * is_writable() not working correctly with ACL permissions.
+     */
+    $isWin = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+    /**
+     * $isWin related checks and is_writable_win() added 04/03/2015 by Yola
+     * Circumvent PHP bug with is_writable not handling ACLs correctly on
+     * Windows platfrom.
+     */
+    if((!$isWin && !@is_writable($smarty->compile_dir)) || ($isWin && !is_writable_win($smarty->compile_dir))) {
         // compile_dir not writable, see if it exists
         if(!@is_dir($smarty->compile_dir)) {
             $smarty->trigger_error('the $compile_dir \'' . $smarty->compile_dir . '\' does not exist, or is not a directory.', E_USER_ERROR);

--- a/libs/internals/core.write_compiled_resource.php
+++ b/libs/internals/core.write_compiled_resource.php
@@ -7,11 +7,7 @@
 
 /**
  * Check to see if the path is writable, works on Windows platforms
- * Based from http://php.net/manual/en/function.is-writable.php comment by
- * legolas558
- *
- * Added 04/03/2015 by Yola to address is_writable PHP bug that does not
- * correctly handle ACL on Windows platforms.
+ * See http://php.net/manual/en/function.is-writable.php comments
  */
 function isWritable($path)
 {
@@ -54,10 +50,6 @@ function isWritable($path)
  */
 function smarty_core_write_compiled_resource($params, &$smarty)
 {
-    /**
-     * Replaced `is_writable` with `isWritable` 04/03/2015 by Yola
-     * Avoids PHP bug with `is_writable` on Windows platform
-     */
     if(!@isWritable($smarty->compile_dir)) {
         // compile_dir not writable, see if it exists
         if(!@is_dir($smarty->compile_dir)) {

--- a/libs/internals/core.write_compiled_resource.php
+++ b/libs/internals/core.write_compiled_resource.php
@@ -48,7 +48,7 @@ function smarty_core_write_compiled_resource($params, &$smarty)
      * Added 04/03/2015 by Yola. Necessary to avoid bug in PHP with
      * is_writable() not working correctly with ACL permissions.
      */
-    $isWin = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+    $isWin = strtoupper(substr(php_uname('s'), 0, 3)) === 'WIN';
     /**
      * $isWin related checks and is_writable_win() added 04/03/2015 by Yola
      * Circumvent PHP bug with is_writable not handling ACLs correctly on

--- a/libs/internals/core.write_compiled_resource.php
+++ b/libs/internals/core.write_compiled_resource.php
@@ -19,13 +19,13 @@ function isWritable($path)
 
     if($isWin) {
         if ($path{strlen($path) - 1} == '/') {
-            return isWritable($path.uniqid(mt_rand()) . '.tmp');
+            $path = $path . uniqid(mt_rand() . '.tmp');
         } elseif (is_dir($path)) {
-            return isWritable($path . '/' . uniqid(mt_rand()) . 'tmp');
+            $path = $path . DIRECTORY_SEPARATOR . uniqid(mt_rand() . 'tmp');
         }
 
         // check tmp file for read/write capabilities
-        $rm = file_exists($path);
+        $newFile = !file_exists($path);
         $f = @fopen($path, 'a');
 
         if ($f === false) {
@@ -34,7 +34,8 @@ function isWritable($path)
 
         fclose($f);
 
-        if (!$rm) {
+        // if the file was created by fopen, delete it
+        if ($newFile) {
             unlink($path);
         }
 

--- a/libs/internals/core.write_compiled_resource.php
+++ b/libs/internals/core.write_compiled_resource.php
@@ -14,7 +14,7 @@ function isWritable($path)
     $isWin = strtoupper(substr(php_uname('s'), 0, 3)) === 'WIN';
 
     if($isWin) {
-        if ($path{strlen($path) - 1} == '/') {
+        if (substr($path, -1) == '/') {
             $path = $path . uniqid(mt_rand() . '.tmp');
         } elseif (is_dir($path)) {
             $path = $path . DIRECTORY_SEPARATOR . uniqid(mt_rand() . 'tmp');


### PR DESCRIPTION
ping @stefanor 

See https://github.com/yola/p-whitelabel/issues/327 for discussion of motivations.

See http://php.net/manual/en/function.is-writable.php comments that suggest this is a bug with PHP on Windows platforms not handling ACLs correctly.
