### PR TITLE
Rename constructor function to avoid php7 warnings

### DIFF
--- a/libs/Smarty_Compiler.class.php
+++ b/libs/Smarty_Compiler.class.php
@@ -78,7 +78,7 @@ class Smarty_Compiler extends Smarty {
     /**
      * The class constructor.
      */
-    function Smarty_Compiler()
+    function __construct()
     {
         // matches double quoted strings:
         // "foobar"


### PR DESCRIPTION
@stefanor  We discussed this last week or something.