### PR TITLE
create_function is deprecated in PHP 7.2

### DIFF
--- a/libs/Smarty_Compiler.class.php
+++ b/libs/Smarty_Compiler.class.php
@@ -262,12 +262,15 @@ class Smarty_Compiler extends Smarty {
         reset($this->_folded_blocks);
 
         /* replace special blocks by "{php}" */
-        $source_content = preg_replace_callback($search, create_function ('$matches', "return '"
-                                       . $this->_quote_replace($this->left_delimiter) . 'php'
-                                       . "' . str_repeat(\"\n\", substr_count('\$matches[1]', \"\n\")) .'"
-                                       . $this->_quote_replace($this->right_delimiter)
-                                       . "';")
-                                       , $source_content);
+        $left_delimiter = $this->left_delimiter;
+        $right_delimiter = $this->right_delimiter;
+        $source_content = preg_replace_callback($search,
+            function($matches) use ($left_delimiter, $right_delimiter)  {
+                return $left_delimiter
+                    . 'php'
+                    . str_repeat("\n", substr_count($matches[1], "\n"))
+                    . $right_delimiter;
+            }, $source_content);
 
         /* Gather all template tags. */
         preg_match_all("~{$ldq}\s*(.*?)\s*{$rdq}~s", $source_content, $_match);


### PR DESCRIPTION
Anonymous functions have been available since PHP 5.3, which is good enough for us.

In my testing, I don't think the `str_repeat` bit was actually working before, but I can't figure out why.